### PR TITLE
Added support for City table and most needed Place fields

### DIFF
--- a/LittleHelpBook/Server/Controllers/CityController.cs
+++ b/LittleHelpBook/Server/Controllers/CityController.cs
@@ -1,0 +1,42 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AirtableApiClient;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
+using GoogleMapsComponents.Maps;
+using LittleHelpBook.Server.Services;
+using LittleHelpBook.Shared.Data;
+
+namespace LittleHelpBook.Server.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class CityController : ControllerBase
+    {
+     
+        private readonly ILogger<PlaceController> logger;
+        private readonly AirTableService _airTableService;
+
+        public CityController(ILogger<PlaceController> logger, AirTableService airTableService)
+        {
+            this.logger = logger;
+            _airTableService = airTableService;
+        }
+
+        [HttpGet]
+        public async Task<IEnumerable<City>> Get()
+        {
+
+            //var data = await _airTableService.GetCitiesPopulatedAsync();
+            var data = await _airTableService.GetCitiesAsync();
+
+            return data.OrderBy(o => o.Name).ToArray();
+
+        }
+
+    }
+}

--- a/LittleHelpBook/Server/Services/AirTableService.cs
+++ b/LittleHelpBook/Server/Services/AirTableService.cs
@@ -18,6 +18,7 @@ namespace LittleHelpBook.Server.Services
         private IEnumerable<Place> _places;  
         private IEnumerable<Category> _categories;
         private IEnumerable<Subcategory> _subcategories;
+        private IEnumerable<City> _cities;
         private IEnumerable<Alert> _alerts;
         private IEnumerable<Info> _infos;
 
@@ -74,6 +75,12 @@ namespace LittleHelpBook.Server.Services
             _subcategories ??= await GetSubcategoriesAsync();
 
             return _subcategories.FirstOrDefault(c => c.Id == id);
+        }
+
+        public async Task<IEnumerable<City>> GetCitiesAsync()
+        //public async Task<City> GetCitiesAsync()
+        {
+            return _cities ??= await GetTableAsync<City>("Cities");
         }
 
         public async Task<IEnumerable<Place>> GetPlacesPopulatedAsync()
@@ -153,6 +160,7 @@ namespace LittleHelpBook.Server.Services
          _subcategories = null;
          _alerts = null;
          _infos = null;
+         _cities = null;
         }
     }
 }

--- a/LittleHelpBook/Shared/Data/HelpModels.cs
+++ b/LittleHelpBook/Shared/Data/HelpModels.cs
@@ -48,8 +48,19 @@ namespace LittleHelpBook.Shared.Data
         public string Email { get; set; }
         [JsonProperty("Hours of Operation")]
         public string Hours { get; set; }
+        [JsonProperty("Hours of Operation-ES")]
+        public string HoursSpanish { get; set; }
 
         public string Description { get; set; }
+
+        [JsonProperty("Description-ES")]
+        public string DescriptionSpanish { get; set; }
+        [JsonProperty("Wheelchair access (y)")]
+        public string Wheelchair { get; set; }
+        [JsonProperty("Language Help (y)")]
+        public string LanguageHelp { get; set; }
+
+        //public string City { get; set; }
     }
 
     public class Category : IAirtable
@@ -73,6 +84,12 @@ namespace LittleHelpBook.Shared.Data
         [JsonProperty("Name-ES")]
         public string NameSpanish { get; set; }
 
+    }
+
+    public class City : IAirtable
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
     }
 
     public class Alert : IAirtable


### PR DESCRIPTION
Added support for City table, and most missing Place fields. Tested running the server locally. 

This is a draft pull request so I can get feedback. 

Ideally I would like to add support for the CatSubcats table and the two still-missing Place fields (City and CatSubcats) before merging. They are links to records in other tables. I wonder if the way subcategories are handled in the HelpModels.cs Category class is a model for how to handle this, namely these lines: 
```
        [JsonProperty("Subcategories")]
        public List<string> Subcategories { get; set; } = new List<string>();
        public List<Subcategory> SubcategoryList { get; set; } = new List<Subcategory>();
```